### PR TITLE
Fixed buffer underrun on invalid configuration.

### DIFF
--- a/xrr-events.cpp
+++ b/xrr-events.cpp
@@ -68,7 +68,7 @@ bool split_line(char *linebuf, std::string &k, std::string &v, bool &arg_provide
         return false;
 
     char *assign_pos = strchr(linebuf, '=');
-    if (!assign_pos) {
+    if (!assign_pos || assign_pos == linebuf) {
         k.assign(linebuf, l-1);
         arg_provided = false;
         return true;


### PR DESCRIPTION
If a configuration file contains a line which starts
with an equal sign (=), xrr-events triggers an out
of boundary access.

The code in questions assumes that there will be at
least one character before the equal sign and starts
scanning for whitespace characters.

The illegal access can be seen when xrr-events is
compiled with ASAN.

$ echo = > $HOME/.config/xrr-events/xrr-events.conf

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>