### PR TITLE
Fixed buffer overrun with malicious pid file.

### DIFF
--- a/xrr-events.cpp
+++ b/xrr-events.cpp
@@ -430,7 +430,7 @@ class PidFile {/*{{{*/
             }
 
             //kill any trailing newlines
-            for (size_t i=l-1; i >= 0; --i) {
+            for (size_t i=l-1; i > 0; --i) {
                 if (linebuf[i] == '\n' || linebuf[i] == '\r')
                     linebuf[i] = '\x00';
                 else


### PR DESCRIPTION
If a process which has '\r' as name writes its pid into the pid file
of xrr-events, the next program start triggers an out of boundary
read. It can be seen when xrr-events is compiled with ASAN.

The problem here is that size_t is used in a loop with a check for
positive values or zero. The type size_t is unsigned, so the for-loop
won't stop, leading to an overflow.

It's safe to simply skip the clean up of the first character here,
making the patch as easy to review as possible. If the string is
shorter than PROGRAM_NAME, the test will fail afterwards in any case.

If in doubt if such a process can exist on Linux systems:

$ ln -s /bin/sh $(echo -ne '\r')
$ ./$(echo -ne '\r')
$ cat /proc/$$/comm

$ ^D
$ rm $(echo -ne '\r')

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>